### PR TITLE
Fixing error if PHPExiftoolServiceProvider is not set.

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,8 +90,11 @@ use Silex\Application;
 use MediaAlchemyst\Alchemyst;
 use MediaAlchemyst\MediaAlchemystServiceProvider;
 use MediaVorus\MediaVorusServiceProvider;
+use PHPExiftool\PHPExiftoolServiceProvider;
 
 $app = new Application();
+
+$app->register(new PHPExiftoolServiceProvider());
 $app->register(new MediaAlchemystSerciceProvider());
 
 // Have fun OH YEAH


### PR DESCRIPTION
This is the fatal error I got:

Fatal error: Uncaught exception 'MediaVorus\Exception\RuntimeException' with message 'MediaVorus Service Provider requires Exiftool Service Provider' in vendor/mediavorus/mediavorus/src/MediaVorus/MediaVorusServiceProvider.php on line 46
