### PR TITLE
Add flatten property for image spec

### DIFF
--- a/src/MediaAlchemyst/Specification/Image.php
+++ b/src/MediaAlchemyst/Specification/Image.php
@@ -25,6 +25,7 @@ class Image extends AbstractSpecification
     protected $resolution_x = 72;
     protected $resolution_y = 72;
     protected $resolution_units = self::RESOLUTION_PIXELPERINCH;
+    protected $flatten = false;
 
     const RESIZE_MODE_INBOUND = ImageInterface::THUMBNAIL_INSET;
     const RESIZE_MODE_INBOUND_FIXEDRATIO = 'inset_fixedRatio';
@@ -130,5 +131,15 @@ class Image extends AbstractSpecification
     public function getStrip()
     {
         return $this->strip;
+    }
+
+    public function setFlatten($boolean)
+    {
+        $this->flatten = (Boolean) $boolean;
+    }
+
+    public function isFlatten()
+    {
+        return $this->flatten;
     }
 }

--- a/src/MediaAlchemyst/Transmuter/Document2Image.php
+++ b/src/MediaAlchemyst/Transmuter/Document2Image.php
@@ -55,6 +55,7 @@ class Document2Image extends AbstractTransmuter
                 'resolution-units' => $spec->getResolutionUnit(),
                 'resolution-x'     => $spec->getResolutionX(),
                 'resolution-y'     => $spec->getResolutionY(),
+                'flatten'          => $spec->isFlatten(),
             );
 
             if ($spec->getWidth() && $spec->getHeight()) {

--- a/src/MediaAlchemyst/Transmuter/Flash2Image.php
+++ b/src/MediaAlchemyst/Transmuter/Flash2Image.php
@@ -59,6 +59,7 @@ class Flash2Image extends AbstractTransmuter
                 'resolution-units' => $spec->getResolutionUnit(),
                 'resolution-x'     => $spec->getResolutionX(),
                 'resolution-y'     => $spec->getResolutionY(),
+                'flatten'          => $spec->isFlatten(),
             );
 
             $image->save($dest, $options);

--- a/src/MediaAlchemyst/Transmuter/Image2Image.php
+++ b/src/MediaAlchemyst/Transmuter/Image2Image.php
@@ -130,7 +130,7 @@ class Image2Image extends AbstractTransmuter
             }
 
             $options = array(
-                'flatten'          => strtolower(pathinfo($dest, PATHINFO_EXTENSION)) !== 'gif',
+                'flatten'          => $spec->isFlatten() && strtolower(pathinfo($dest, PATHINFO_EXTENSION)) !== 'gif',
                 'quality'          => $spec->getQuality(),
                 'resolution-units' => $spec->getResolutionUnit(),
                 'resolution-x'     => $spec->getResolutionX(),

--- a/src/MediaAlchemyst/Transmuter/Video2Image.php
+++ b/src/MediaAlchemyst/Transmuter/Video2Image.php
@@ -89,6 +89,7 @@ class Video2Image extends AbstractTransmuter
                 'resolution-units' => $spec->getResolutionUnit(),
                 'resolution-x'     => $spec->getResolutionX(),
                 'resolution-y'     => $spec->getResolutionY(),
+                'flatten'          => $spec->isFlatten(),
             );
 
             $image->save($dest, $options);

--- a/tests/MediaAlchemyst/Tests/Specification/ImageTest.php
+++ b/tests/MediaAlchemyst/Tests/Specification/ImageTest.php
@@ -141,4 +141,16 @@ class ImageTest extends \PHPUnit_Framework_TestCase
         $this->object->setStrip(false);
         $this->assertEquals(false, $this->object->getStrip());
     }
+
+    /**
+     * @covers MediaAlchemyst\Specification\Image::setFlatten
+     * @covers MediaAlchemyst\Specification\Image::isFlatten
+     */
+    public function testSetFlatten()
+    {
+        $this->object->setFlatten(true);
+        $this->assertEquals(true, $this->object->isFlatten());
+        $this->object->setFlatten(false);
+        $this->assertEquals(false, $this->object->isFlatten());
+    }
 }


### PR DESCRIPTION
Allow to set a flatten property in image spec to collapse all layers of an image.
