### PR TITLE
force freeing of memory kept by Imagick till the end of script.

### DIFF
--- a/src/MediaAlchemyst/Transmuter/Image2Image.php
+++ b/src/MediaAlchemyst/Transmuter/Image2Image.php
@@ -78,6 +78,9 @@ class Image2Image extends AbstractTransmuter
                     $layers[] = $tmpFile;
                 }
 
+                unset($image);
+                gc_collect_cycles();
+
                 uasort($layers, function ($layer1, $layer2) {
                     $size1 = filesize($layer1);
                     $size2 = filesize($layer2);
@@ -100,6 +103,9 @@ class Image2Image extends AbstractTransmuter
                     }
                     break;
                 }
+
+                unset($image);
+                gc_collect_cycles();
             }
 
             $image = $this->container['imagine']->open($source->getFile()->getPathname());
@@ -138,6 +144,10 @@ class Image2Image extends AbstractTransmuter
             );
 
             $image->save($dest, $options);
+
+            unset($image);
+            gc_collect_cycles();
+
             $this->tmpFileManager->clean(self::TMP_FILE_SCOPE);
         } catch (MediaVorusException $e) {
             $this->tmpFileManager->clean(self::TMP_FILE_SCOPE);


### PR DESCRIPTION
prevents eating memory when many images are converted 
