### PR TITLE
Force freeing of memory kept by Imagick till the end of script.

### DIFF
--- a/src/MediaAlchemyst/Transmuter/Audio2Audio.php
+++ b/src/MediaAlchemyst/Transmuter/Audio2Audio.php
@@ -52,6 +52,8 @@ class Audio2Audio extends AbstractTransmuter
 
         try {
             $audio->save($format, $dest);
+
+            unset($audio);
         } catch (FFMpegException $e) {
             throw new RuntimeException('Unable to transmute audio to audio due to FFMpeg', null, $e);
         }

--- a/src/MediaAlchemyst/Transmuter/Document2Image.php
+++ b/src/MediaAlchemyst/Transmuter/Document2Image.php
@@ -72,6 +72,9 @@ class Document2Image extends AbstractTransmuter
             }
 
             $image->save($dest, $options);
+
+            unset($image);
+
             $this->tmpFileManager->clean(self::TMP_FILE_SCOPE);
         } catch (GhostscriptException $e) {
             $this->tmpFileManager->clean(self::TMP_FILE_SCOPE);

--- a/src/MediaAlchemyst/Transmuter/Flash2Image.php
+++ b/src/MediaAlchemyst/Transmuter/Flash2Image.php
@@ -63,6 +63,9 @@ class Flash2Image extends AbstractTransmuter
             );
 
             $image->save($dest, $options);
+
+            unset($image);
+
             $this->tmpFileManager->clean(self::TMP_FILE_SCOPE);
         } catch (BinaryAdapterException $e) {
             $this->tmpFileManager->clean(self::TMP_FILE_SCOPE);

--- a/src/MediaAlchemyst/Transmuter/Image2Image.php
+++ b/src/MediaAlchemyst/Transmuter/Image2Image.php
@@ -79,7 +79,6 @@ class Image2Image extends AbstractTransmuter
                 }
 
                 unset($image);
-                gc_collect_cycles();
 
                 uasort($layers, function ($layer1, $layer2) {
                     $size1 = filesize($layer1);
@@ -105,7 +104,6 @@ class Image2Image extends AbstractTransmuter
                 }
 
                 unset($image);
-                gc_collect_cycles();
             }
 
             $image = $this->container['imagine']->open($source->getFile()->getPathname());
@@ -146,7 +144,6 @@ class Image2Image extends AbstractTransmuter
             $image->save($dest, $options);
 
             unset($image);
-            gc_collect_cycles();
 
             $this->tmpFileManager->clean(self::TMP_FILE_SCOPE);
         } catch (MediaVorusException $e) {

--- a/src/MediaAlchemyst/Transmuter/Video2Image.php
+++ b/src/MediaAlchemyst/Transmuter/Video2Image.php
@@ -93,7 +93,9 @@ class Video2Image extends AbstractTransmuter
             );
 
             $image->save($dest, $options);
-            $image = null;
+
+            unset($image);
+
             $this->tmpFileManager->clean(self::TMP_FILE_SCOPE);
         } catch (FFMpegException $e) {
             $this->tmpFileManager->clean(self::TMP_FILE_SCOPE);

--- a/src/MediaAlchemyst/Transmuter/Video2Video.php
+++ b/src/MediaAlchemyst/Transmuter/Video2Video.php
@@ -112,6 +112,8 @@ class Video2Video extends AbstractTransmuter
             if ($format instanceof X264) {
                 $this->container['mp4box']->process($dest);
             }
+
+            unset($video);
         } catch (FFMpegException $e) {
             throw new RuntimeException('Unable to transmute video to video due to FFMpeg', null, $e);
         } catch (MP4BoxException $e) {


### PR DESCRIPTION
unset memoryvore php variables to be able to free memory by calling gc_collect_cycle() in php script when using transmuters within a loop for example.
