### PR TITLE
Add a "codec" to the image specification

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ before_script:
   - sh -c "cd imagick-$IMAGICK_VERSION && phpize && ./configure --with-imagick=/usr/local && make -j && sudo make install"
   - echo "extension=imagick.so" >> `php --ini | grep "Loaded Configuration" | sed -e "s|.*:\s*||"`
   - composer self-update
+  - if [ "$TRAVIS_PHP_VERSION" = "5.3.3" ]; then composer config disable-tls true; fi
   - composer update --prefer-source --no-interaction $LOW_DEPS
 
 

--- a/composer.json
+++ b/composer.json
@@ -35,8 +35,8 @@
     "require-dev": {
         "phpunit/phpunit"                : "^4.1|^5.0",
         "neutron/silex-imagine-provider" : "~0.1",
-        "phpexiftool/phpexiftool"        : "~0.1",
-        "silex/silex"                    : "~1.0"
+        "silex/silex"                    : "~1.0",
+        "alchemy/phpexiftool": "^0.4.0|^0.5.0"
     },
     "autoload": {
         "psr-0": {

--- a/src/MediaAlchemyst/Specification/Image.php
+++ b/src/MediaAlchemyst/Specification/Image.php
@@ -26,6 +26,7 @@ class Image extends AbstractSpecification
     protected $resolution_y = 72;
     protected $resolution_units = self::RESOLUTION_PIXELPERINCH;
     protected $flatten = false;
+    protected $imageCodec = 'jpeg';
 
     const RESIZE_MODE_INBOUND = ImageInterface::THUMBNAIL_INSET;
     const RESIZE_MODE_INBOUND_FIXEDRATIO = 'inset_fixedRatio';
@@ -36,6 +37,16 @@ class Image extends AbstractSpecification
     public function getType()
     {
         return self::TYPE_IMAGE;
+    }
+
+    public function setImageCodec($imageCodec)
+    {
+        $this->imageCodec = $imageCodec;
+    }
+
+    public function getImageCodec()
+    {
+        return $this->imageCodec;
     }
 
     public function setDimensions($width, $height)

--- a/tests/MediaAlchemyst/Tests/Specification/ImageTest.php
+++ b/tests/MediaAlchemyst/Tests/Specification/ImageTest.php
@@ -29,6 +29,16 @@ class ImageTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @covers MediaAlchemyst\Specification\Image::setImageCodec
+     * @covers MediaAlchemyst\Specification\Image::getImageCodec
+     */
+    public function testCodec()
+    {
+        $this->object->setImageCodec("a_codec");
+        $this->assertEquals("a_codec", $this->object->getImageCodec());
+    }
+
+    /**
      * @covers MediaAlchemyst\Specification\Image::setDimensions
      * @covers MediaAlchemyst\Specification\Image::getWidth
      * @covers MediaAlchemyst\Specification\Image::getHeight


### PR DESCRIPTION
Add a "codec" to the image specification so client can use it to generates different file formats (jpeg, png, tiff, ...)