### PR TITLE
Allow new versions in dependencies to support PHP8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,15 +28,15 @@
         "alchemy/mediavorus": "^0.4.4",
         "imagine/imagine": "^0.11.0",
         "monolog/monolog": "~1.0",
-        "neutron/temporary-filesystem": "^2.1.1",
-        "php-ffmpeg/php-ffmpeg": "^v0.15",
+        "neutron/temporary-filesystem": "^2.1.1|^3.0",
+        "php-ffmpeg/php-ffmpeg": ">=v0.15 <v0.999|^1.0",
         "php-mp4box/php-mp4box": "~0.3.0",
         "php-unoconv/php-unoconv": "~0.3.1",
         "pimple/pimple": "~1.0",
         "swftools/swftools": "~0.3.0",
-        "symfony/console": "^2.1|^3.0",
-        "symfony/filesystem": "^2.1|^3.0",
-        "symfony/process": "^2.1.1|^3.0"
+        "symfony/console": "^2.1|^3.0|^4.0|^5.0|^6.0|^7.0",
+        "symfony/filesystem": "^2.1|^3.0|^4.0|^5.0|^6.0|^7.0",
+        "symfony/process": "^2.1.1|^3.0|^4.0|^5.0|^6.0|^7.0"
     },
     "require-dev": {
         "alchemy/phpexiftool": "^0.4.0|^0.5.0",


### PR DESCRIPTION
This change adds new versions to the list of dependencies to support PHP8 (install tested up to PHP 8.3)

